### PR TITLE
feat: NeonデータベースとDrizzle ORMの連携を設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ cp .env.example .env.local
 # .env.local を編集して必要な環境変数を設定
 ```
 
+### データベースのセットアップ
+
+Neonデータベースの設定とDrizzle ORMの連携については、[DATABASE_SETUP.md](./docs/DATABASE_SETUP.md) を参照してください。
+
+```bash
+# スキーマをデータベースにプッシュ
+npm run db:push
+
+# Drizzle Studio（データベースGUI）を起動
+npm run db:studio
+```
+
 ### 開発サーバーの起動
 
 ```bash

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -1,0 +1,145 @@
+# データベースセットアップガイド
+
+このドキュメントでは、Neon PostgreSQLとDrizzle ORMのセットアップ方法を説明します。
+
+## 前提条件
+
+- Neonアカウント（https://neon.tech）
+- Node.js 18.x 以上
+
+## Neonプロジェクトの作成
+
+### 1. Neonにサインアップ/ログイン
+
+https://console.neon.tech/ にアクセスしてアカウントを作成またはログインします。
+
+### 2. 新しいプロジェクトを作成
+
+1. 「New Project」をクリック
+2. プロジェクト名を入力（例: `mindgames-ticket-dev`）
+3. リージョンを選択（推奨: 近い場所、例: Asia Pacific (Tokyo)）
+4. PostgreSQLバージョンを選択（デフォルトでOK）
+5. 「Create Project」をクリック
+
+### 3. 接続情報を取得
+
+プロジェクト作成後、ダッシュボードに接続文字列が表示されます：
+
+```
+postgresql://[user]:[password]@[endpoint]/[dbname]?sslmode=require
+```
+
+この文字列をコピーしておきます。
+
+## ローカル環境の設定
+
+### 1. 環境変数ファイルの作成
+
+プロジェクトルートで以下のコマンドを実行：
+
+```bash
+cp .env.example .env.local
+```
+
+### 2. DATABASE_URLを設定
+
+`.env.local` ファイルを開き、`DATABASE_URL` にNeonの接続文字列を設定：
+
+```env
+DATABASE_URL=postgresql://[user]:[password]@[endpoint]/[dbname]?sslmode=require
+```
+
+### 3. スキーマをデータベースにプッシュ
+
+```bash
+npm run db:push
+```
+
+このコマンドは、`src/db/schema.ts` で定義されたスキーマをデータベースに適用します。
+
+成功すると以下のようなメッセージが表示されます：
+
+```
+✓ Changes applied
+```
+
+## Drizzle Studio（データベースGUI）
+
+### Drizzle Studioの起動
+
+```bash
+npm run db:studio
+```
+
+ブラウザで https://local.drizzle.studio が開き、データベースの内容を視覚的に確認・編集できます。
+
+### 機能
+
+- テーブルの閲覧
+- データの追加・編集・削除
+- SQLクエリの実行
+- スキーマの確認
+
+## 利用可能なコマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `npm run db:generate` | マイグレーションファイルを生成 |
+| `npm run db:push` | スキーマをデータベースに直接プッシュ（開発用） |
+| `npm run db:migrate` | マイグレーションを実行（本番用） |
+| `npm run db:studio` | Drizzle Studioを起動 |
+
+## スキーマの管理
+
+### スキーマファイルの場所
+
+- **スキーマ定義**: `src/db/schema.ts`
+- **データベース接続**: `src/db/index.ts`
+- **Drizzle設定**: `drizzle.config.ts`
+
+### スキーマの変更手順
+
+1. `src/db/schema.ts` でスキーマを編集
+2. 開発環境の場合: `npm run db:push` で即座に反映
+3. 本番環境の場合:
+   - `npm run db:generate` でマイグレーションファイル生成
+   - `npm run db:migrate` でマイグレーション実行
+
+## トラブルシューティング
+
+### 接続エラーが発生する場合
+
+1. `.env.local` ファイルが存在することを確認
+2. `DATABASE_URL` が正しく設定されていることを確認
+3. Neonプロジェクトが起動していることを確認（NeonはアイドルでスリープすることがあるSleep状態の場合、接続すると自動的に起動します）
+
+### スキーマプッシュが失敗する場合
+
+```bash
+# 環境変数が読み込まれているか確認
+npm run db:push -- --verbose
+```
+
+## 開発環境と本番環境の分離
+
+### ベストプラクティス
+
+- **開発環境**: 別のNeonプロジェクトを作成（例: `mindgames-ticket-dev`）
+- **本番環境**: 本番用のNeonプロジェクト（例: `mindgames-ticket-prod`）
+
+### 環境ごとの設定
+
+```env
+# .env.local（開発環境、gitignore済み）
+DATABASE_URL=postgresql://dev-user:password@dev-endpoint/dbname
+
+# Vercel環境変数（本番環境）
+DATABASE_URL=postgresql://prod-user:password@prod-endpoint/dbname
+```
+
+## 参考資料
+
+- [Neon Documentation](https://neon.tech/docs/introduction)
+- [Drizzle ORM Documentation](https://orm.drizzle.team/docs/overview)
+- [Drizzle with Neon](https://orm.drizzle.team/docs/get-started-postgresql#neon)
+- [TECH_STACK.md](./TECH_STACK.md)

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from "drizzle-kit";
+import { config } from "dotenv";
+
+// Load environment variables from .env.local
+config({ path: ".env.local" });
 
 export default defineConfig({
   schema: "./src/db/schema.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dotenv": "^17.2.3",
         "drizzle-orm": "^0.44.7",
         "lucide-react": "^0.548.0",
         "next": "^15.0.3",
@@ -2227,6 +2228,18 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/drizzle-kit": {
       "version": "0.31.6",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dotenv": "^17.2.3",
     "drizzle-orm": "^0.44.7",
     "lucide-react": "^0.548.0",
     "next": "^15.0.3",


### PR DESCRIPTION
## 概要

ローカル開発環境でNeon PostgreSQLを使用できるように設定し、Drizzle ORMとの連携を確立しました。

## 変更内容

### 設定ファイルの修正
- **drizzle.config.ts**: dotenvを追加し、`.env.local`から環境変数を読み込むように修正
- **package.json**: dotenv パッケージを追加

### ドキュメント作成
- **docs/DATABASE_SETUP.md**: 詳細なセットアップガイドを作成
  - Neonプロジェクトの作成手順
  - ローカル環境の設定方法
  - Drizzle Studioの使い方
  - トラブルシューティング
- **README.md**: データベースセットアップの説明を追加

## 動作確認

✅ `npm run db:push` でスキーマをNeonデータベースにプッシュ成功
✅ `npm run db:studio` でDrizzle Studioが正常に起動
✅ usersテーブルがデータベースに作成されたことを確認

## セットアップ手順（開発者向け）

1. Neonプロジェクトを作成
2. `.env.local` に `DATABASE_URL` を設定
3. `npm run db:push` でスキーマを適用
4. `npm run db:studio` でデータベースを確認

## 次のステップ

これでBetter Authセットアップの準備が整いました。次のPRでBetter Authの実装を進めます。

## チェックリスト

- [x] Neonプロジェクトを作成
- [x] DATABASE_URLを設定
- [x] drizzle.config.tsを修正
- [x] スキーマをDBにプッシュ
- [x] Drizzle Studioで動作確認
- [x] セットアップドキュメント作成

## 関連

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)